### PR TITLE
feat: Add FallbackHighlighter for improved robustness

### DIFF
--- a/src/CodeHighlighter.php
+++ b/src/CodeHighlighter.php
@@ -9,7 +9,7 @@ use PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter;
 
 class CodeHighlighter
 {
-    /** @var Highlighter|OldHighlighter */
+    /** @var FallbackHighlighter|Highlighter|OldHighlighter */
     private $highlighter;
 
     public function __construct()
@@ -28,6 +28,9 @@ class CodeHighlighter
             // Support Highlighter and ConsoleColor < 1.0.
             $colors = new OldConsoleColor();
             $this->highlighter = new OldHighlighter($colors);
+        } else {
+            // Fallback to non-highlighted output
+            $this->highlighter = new FallbackHighlighter();
         }
     }
 

--- a/src/FallbackHighlighter.php
+++ b/src/FallbackHighlighter.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Yamadashy\PhpStanFriendlyFormatter;
+
+use PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter;
+
+/**
+ * @see Highlighter
+ */
+class FallbackHighlighter
+{
+    public function getCodeSnippet(string $fileContent, int $lineNumber, int $lineBefore, int $lineAfter): string
+    {
+        $lines = explode("\n", $fileContent);
+        $totalLines = \count($lines);
+
+        $startLine = max(1, $lineNumber - $lineBefore);
+        $endLine = min($totalLines, $lineNumber + $lineAfter);
+
+        $snippet = '';
+        $lineNumberWidth = \strlen((string) $endLine);
+
+        for ($i = $startLine; $i <= $endLine; ++$i) {
+            $currentLine = $lines[$i - 1] ?? '';
+            $linePrefix = '<fg=gray>'.str_pad((string) $i, $lineNumberWidth, ' ', STR_PAD_LEFT).'| </>';
+            $snippet .= ($lineNumber === $i ? '<fg=red>  > </>' : '    ').$linePrefix.$currentLine."\n";
+        }
+
+        return rtrim($snippet);
+    }
+}


### PR DESCRIPTION
## Changes
- Implemented a new `FallbackHighlighter` class that provides basic code snippet functionality without relying on external highlighting libraries.
  - Updated `CodeHighlighter` to use `FallbackHighlighter` when neither version of PhpConsoleHighlighter is available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `FallbackHighlighter` that provides a fallback option for code highlighting when other highlighters are unavailable.
	- Added a method to extract and format code snippets from file content, allowing users to specify line numbers for better context.

- **Bug Fixes**
	- Enhanced control flow to ensure a fallback highlighter is utilized if primary options are not available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->