### PR TITLE
Use errorFormat parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ includes:
     - ./vendor/yamadashy/phpstan-friendly-formatter/extension.neon
 ```
 
-3. Finaly, use phpstan console command with `--error-format` option:
-```shell
-./vendor/bin/phpstan analyze --error-format friendly
+3. Finally, set the `errorFormat` parameter:
+```neon
+parameters:
+    errorFormat: friendly
 ```
 
 ### Optional: Simplify Your Workflow


### PR DESCRIPTION
... and correct a typo: "Finaly"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated instructions in the README for configuring PHPStan's error formatting, simplifying the process by using a configuration file instead of command line commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->