### PR TITLE
fix(test): support PHPStan 2.2.13 AnalysisResult 13-arg constructor

### DIFF
--- a/tests/FriendlyErrorFormatterTest.php
+++ b/tests/FriendlyErrorFormatterTest.php
@@ -296,7 +296,8 @@ final class FriendlyErrorFormatterTest extends ErrorFormatterTestCase
             return new AnalysisResult($fileErrors, $genericErrors, [], $warnings, [], false, null, true, memory_get_peak_usage(true), true, [], []);
         }
 
+        // compatibility to 2.2.13 or later (added $resultCacheExisted, $workerCount)
         // @phpstan-ignore-next-line
-        return new AnalysisResult($fileErrors, $genericErrors, [], $warnings, [], false, null, true, memory_get_peak_usage(true), true, [], []);
+        return new AnalysisResult($fileErrors, $genericErrors, [], $warnings, [], false, null, true, memory_get_peak_usage(true), true, [], true, 0);
     }
 }


### PR DESCRIPTION
PHPStan 2.2.13 (2026-09-03) changed `AnalysisResult::__construct` to 13 parameters, adding `bool $resultCacheExisted` as argument 12 and `int $workerCount` as argument 13. The test fallback passed an array as argument 12, causing:

```
TypeError: PHPStan\Command\AnalysisResult::__construct(): Argument #12 ($resultCacheExisted) must be of type bool, array given
```

This surfaced in #53's CI (prefer-stable). main itself fails the same way against the latest PHPStan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)